### PR TITLE
fix: ingress-nginx release update

### DIFF
--- a/.github/workflows/update_version_badge.yaml
+++ b/.github/workflows/update_version_badge.yaml
@@ -1,0 +1,32 @@
+name: Update Version Badge
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  update-version-badge:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Install Helm
+      uses: azure/setup-helm@v3
+      with:
+        version: v3.13.3
+
+    - name: Update Version Badge
+      run: |
+        NEW_VERSION=$(helm show chart oci://ghcr.io/daytonaio/charts/watkins 2>/dev/null | grep 'appVersion:' | awk '{print $2}')
+        sed -i "s/APP_VERSION-[0-9]\+\.[0-9]\+\.[0-9]-blue\+/APP_VERSION-$NEW_VERSION-blue/g" README.md
+
+    - name: Commit README.md
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        file_pattern: README.md
+        branch: main
+        commit_message: 'docs: update README.md version badge [skip ci]'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.yaml
+!.github/**/*.yaml

--- a/setup.sh
+++ b/setup.sh
@@ -278,6 +278,8 @@ controller:
     enabled: true
   service:
     type: ClusterIP
+  updateStrategy:
+    type: Recreate
 EOF
 
 }


### PR DESCRIPTION
* change update strategy on ingress-nginx to resolve issue with node ports unavailable during rolling update
* add GHA to show app version in README